### PR TITLE
add token to social auth redirect

### DIFF
--- a/app/controllers/SocialAuthController.scala
+++ b/app/controllers/SocialAuthController.scala
@@ -37,7 +37,7 @@ class SocialAuthController @Inject() (
             _ <- authInfoRepository.save(profile.loginInfo, authInfo)
             authenticator <- silhouette.env.authenticatorService.create(profile.loginInfo)
             token <- silhouette.env.authenticatorService.init(authenticator)
-            result <- silhouette.env.authenticatorService.embed(token, Redirect(s"${userState.state("redirect")}?token=$token"))
+            result <- Future.successful(Redirect(s"${userState.state("redirect")}?token=$token"))
           } yield {
 
             val url = routes.ActivateAccountController.activate(token, userState.state("redirect")).absoluteURL()

--- a/app/controllers/SocialAuthController.scala
+++ b/app/controllers/SocialAuthController.scala
@@ -37,7 +37,7 @@ class SocialAuthController @Inject() (
             _ <- authInfoRepository.save(profile.loginInfo, authInfo)
             authenticator <- silhouette.env.authenticatorService.create(profile.loginInfo)
             token <- silhouette.env.authenticatorService.init(authenticator)
-            result <- silhouette.env.authenticatorService.embed(token, Redirect(userState.state("redirect")))
+            result <- silhouette.env.authenticatorService.embed(token, Redirect(s"${userState.state("redirect")}?token=$token"))
           } yield {
 
             val url = routes.ActivateAccountController.activate(token, userState.state("redirect")).absoluteURL()


### PR DESCRIPTION
Related to: https://github.com/yujinjcho/rcruitme-front/pull/19

Er how do you feel about this? Frontend is unable to access headers of initial request on redirect from google.